### PR TITLE
Feat/new houses

### DIFF
--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/Rentable.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/Rentable.kt
@@ -14,6 +14,10 @@ import org.jetbrains.annotations.Unmodifiable
 import java.time.ZonedDateTime
 import kotlin.time.Duration
 
+/**
+ * Represents a rentable property in the game.
+ * A rentable property can be owned, rented, and have members associated with it.
+ */
 interface Rentable : ComponentLike {
 
     /**

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableMemberAddEvent.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableMemberAddEvent.kt
@@ -4,18 +4,48 @@ import dev.slne.surf.roleplay.api.events.CancellableRpEvent
 import dev.slne.surf.roleplay.api.mechanic.rentable.Rentable
 import dev.slne.surf.roleplay.api.player.RpPlayer
 
+/**
+ * Event triggered when a member is added to a rentable property.
+ * This event is cancellable, allowing plugins to prevent the addition of a member.
+ *
+ * @property rentable The rentable property to which the member is being added.
+ * @property member The player who is being added as a member to the rentable property.
+ */
 class RentableMemberAddEvent(
     val rentable: Rentable,
     val member: RpPlayer,
 ) : CancellableRpEvent() {
 
+    /**
+     * The result of the member addition operation.
+     */
     sealed class MemberAddResult {
+        /**
+         * Indicates a successful addition of the member to the rentable property.
+         */
         data object Success : MemberAddResult()
+
+        /**
+         * Indicates a failure in adding the member to the rentable property.
+         * Contains the reason for the failure.
+         *
+         * @property reason The reason why the addition failed.
+         */
         data class Failure(val reason: MemberAddFailureReason) : MemberAddResult()
     }
 
+    /**
+     * Represents the reasons why adding a member to a rentable property might fail.
+     */
     sealed class MemberAddFailureReason {
+        /**
+         * Indicates that the member is already part of the rentable property.
+         */
         data object AlreadyMember : MemberAddFailureReason()
+
+        /**
+         * Indicates that the rentable property is full and cannot accommodate more members.
+         */
         data object EventCancelled : MemberAddFailureReason()
     }
 }

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableMemberAddEvent.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableMemberAddEvent.kt
@@ -44,7 +44,7 @@ class RentableMemberAddEvent(
         data object AlreadyMember : MemberAddFailureReason()
 
         /**
-         * Indicates that the rentable property is full and cannot accommodate more members.
+         * Indicates that the addition of the member was cancelled by an event handler.
          */
         data object EventCancelled : MemberAddFailureReason()
     }

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableMemberRemoveEvent.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableMemberRemoveEvent.kt
@@ -4,18 +4,48 @@ import dev.slne.surf.roleplay.api.events.CancellableRpEvent
 import dev.slne.surf.roleplay.api.mechanic.rentable.Rentable
 import dev.slne.surf.roleplay.api.player.RpPlayer
 
+/**
+ * Event triggered when a member is removed from a rentable property.
+ * This event is cancellable, allowing plugins to prevent the removal of a member.
+ *
+ * @property rentable The rentable property from which the member is being removed.
+ * @property member The player who is being removed as a member from the rentable property.
+ */
 class RentableMemberRemoveEvent(
     val rentable: Rentable,
     val member: RpPlayer,
 ) : CancellableRpEvent() {
 
+    /**
+     * The result of the member removal operation.
+     */
     sealed class MemberRemoveResult {
+        /**
+         * Indicates a successful removal of the member from the rentable property.
+         */
         data object Success : MemberRemoveResult()
+
+        /**
+         * Indicates a failure in removing the member from the rentable property.
+         * Contains the reason for the failure.
+         *
+         * @property reason The reason why the removal failed.
+         */
         data class Failure(val reason: MemberRemoveFailureReason) : MemberRemoveResult()
     }
 
+    /**
+     * Represents the reasons why removing a member from a rentable property might fail.
+     */
     sealed class MemberRemoveFailureReason {
+        /**
+         * Indicates that the member is not part of the rentable property.
+         */
         data object NotMember : MemberRemoveFailureReason()
+
+        /**
+         * Indicates that the event was cancelled, preventing the member from being removed.
+         */
         data object EventCancelled : MemberRemoveFailureReason()
     }
 }

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableOwnerChangeEvent.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableOwnerChangeEvent.kt
@@ -6,6 +6,15 @@ import dev.slne.surf.roleplay.api.mechanic.rentable.RentableMechanic
 import dev.slne.surf.roleplay.api.player.RpPlayer
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 
+/**
+ * Event triggered when the owner of a rentable property changes.
+ * This event is cancellable, allowing plugins to prevent the owner change.
+ *
+ * @property rentable The rentable property whose owner is changing.
+ * @property oldOwner The previous owner of the rentable property, or null if there was no previous owner.
+ * @property newOwner The new owner of the rentable property, or null if the ownership is being removed.
+ * @property reason The reason for the owner change.
+ */
 class RentableOwnerChangeEvent(
     val rentable: Rentable,
     val oldOwner: RpPlayer?,
@@ -13,24 +22,69 @@ class RentableOwnerChangeEvent(
     val reason: OwnerChangeReason,
 ) : CancellableRpEvent() {
 
+    /**
+     * The reason why the owner change was cancelled, if applicable.
+     */
     var cancelReason: String? = null
 
+    /**
+     * The result of the owner change operation.
+     */
     sealed class OwnerChangeReason {
-        data object PlayerQuit : OwnerChangeReason()
+        /**
+         * The owner quit the game, resulting in the owner change.
+         */
+        data object OwnerQuit : OwnerChangeReason()
+
+        /**
+         * The owner of the rentable property was removed, resulting in the owner change.
+         */
         data object RentableBought : OwnerChangeReason()
+
+        /**
+         * The owner of the rentable property was changed to a new owner.
+         */
         data object OwnerSetNewOwner : OwnerChangeReason()
     }
 
+    /**
+     * The result of setting a new owner for the rentable property.
+     */
     sealed class OwnerSetResult {
+        /**
+         * Indicates a successful owner change operation.
+         */
         data object Success : OwnerSetResult()
+
+        /**
+         * Indicates a failure in setting the new owner for the rentable property.
+         * Contains the reason for the failure.
+         *
+         * @property reason The reason why the owner change failed.
+         */
         data class Failure(val reason: OwnerSetFailureReason) : OwnerSetResult()
     }
 
+    /**
+     * Represents the reasons why setting a new owner for a rentable property might fail.
+     *
+     * @property message A function that builds a message describing the failure reason.
+     */
     sealed class OwnerSetFailureReason(val message: SurfComponentBuilder.() -> Unit) {
+
+        /**
+         * Indicates that the new owner is already a member of the rentable property.
+         */
         data object AlreadyOwned : OwnerSetFailureReason({
             error("Dieses Mietobjekt wird bereits von jemand anderem besessen.")
         })
 
+        /**
+         * Indicates that the new owner already has too many rentable properties.
+         *
+         * @param ownedRentables The number of rentable properties the owner currently has.
+         * @param maxOwnableRentables The maximum number of rentable properties the owner can have.
+         */
         data class AlreadyOwningTooManyRentables(
             val ownedRentables: Int,
             val maxOwnableRentables: Int
@@ -42,6 +96,12 @@ class RentableOwnerChangeEvent(
             error(" und kannst kein weiteres besitzen.")
         })
 
+        /**
+         * Indicates that the new owner does not have enough money to buy the rentable property.
+         *
+         * @param currentMoney The amount of money the new owner currently has.
+         * @param requiredMoney The amount of money required to buy the rentable property.
+         */
         data class NotEnoughMoney(
             val currentMoney: Int,
             val requiredMoney: Int
@@ -53,6 +113,11 @@ class RentableOwnerChangeEvent(
             error(" benötigt.")
         })
 
+        /**
+         * Indicates that the rent collection failed for the rentable property.
+         *
+         * @param reason The reason for the rent collection failure.
+         */
         data class RentCollectionFailed(
             val reason: RentableMechanic.RentCollectResult
         ) : OwnerSetFailureReason({
@@ -60,6 +125,11 @@ class RentableOwnerChangeEvent(
             variableValue(reason.name)
         })
 
+        /**
+         * Indicates that the event was cancelled, preventing the owner change.
+         *
+         * @param reason The reason why the event was cancelled.
+         */
         data class EventCancelled(val reason: String) : OwnerSetFailureReason({
             error("Das Event wurde abgebrochen: ")
             variableValue(reason)

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableRentCollectEvent.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableRentCollectEvent.kt
@@ -3,6 +3,13 @@ package dev.slne.surf.roleplay.api.mechanic.rentable.events
 import dev.slne.surf.roleplay.api.events.CancellableRpEvent
 import dev.slne.surf.roleplay.api.mechanic.rentable.Rentable
 
+/**
+ * Event triggered when rent is collected from a rentable property.
+ * This event is cancellable, allowing plugins to prevent the rent collection.
+ *
+ * @property rentable The rentable property from which the rent is being collected.
+ * @property amount The amount of rent being collected.
+ */
 class RentableRentCollectEvent(
     val rentable: Rentable,
     var amount: Int,

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/rentables/Apartment.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/rentables/Apartment.kt
@@ -2,4 +2,7 @@ package dev.slne.surf.roleplay.api.mechanic.rentable.rentables
 
 import dev.slne.surf.roleplay.api.mechanic.rentable.Rentable
 
+/**
+ * Represents an apartment that can be rented.
+ */
 interface Apartment : Rentable

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/rentables/House.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/rentables/House.kt
@@ -2,4 +2,7 @@ package dev.slne.surf.roleplay.api.mechanic.rentable.rentables
 
 import dev.slne.surf.roleplay.api.mechanic.rentable.Rentable
 
+/**
+ * Represents a house that can be rented.
+ */
 interface House : Rentable

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/Crackable.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/Crackable.kt
@@ -3,6 +3,10 @@ package dev.slne.surf.roleplay.api.mechanic.rentable.utils
 import dev.slne.surf.roleplay.api.player.RpPlayer
 import kotlin.time.Duration
 
+/**
+ * Represents an entity that can be cracked, such as a lock on a door or a vault.
+ * This interface defines the properties and methods required for cracking functionality.
+ */
 interface Crackable {
 
     /**

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/LockPick.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/LockPick.kt
@@ -3,6 +3,9 @@ package dev.slne.surf.roleplay.api.mechanic.rentable.utils
 import dev.slne.surf.roleplay.api.player.RpPlayer
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 
+/**
+ * Represents a lock pick that can be used to pick locks.
+ */
 interface LockPick {
 
     /**

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/Lockable.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/Lockable.kt
@@ -2,6 +2,9 @@ package dev.slne.surf.roleplay.api.mechanic.rentable.utils
 
 import dev.slne.surf.roleplay.api.player.RpPlayer
 
+/**
+ * Represents an entity that can be locked and accessed by players.
+ */
 interface Lockable {
     /**
      * Checks if the player can access this lockable.

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/StorageContainer.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/StorageContainer.kt
@@ -6,6 +6,9 @@ import org.bukkit.Material
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Represents a storage container that can be placed in the world and is associated with a rentable property.
+ */
 interface StorageContainer {
 
     /**

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/door/Door.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/door/Door.kt
@@ -5,6 +5,10 @@ import dev.slne.surf.roleplay.api.mechanic.rentable.utils.Crackable
 import dev.slne.surf.roleplay.api.mechanic.rentable.utils.Lockable
 import org.bukkit.Location
 
+/**
+ * Represents a door in the game that can be locked and cracked.
+ * A door is associated with a rentable property and has a specific location in the world.
+ */
 interface Door : Lockable, Crackable {
 
     /**

--- a/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/door/DoorContainer.kt
+++ b/surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/utils/door/DoorContainer.kt
@@ -2,6 +2,9 @@ package dev.slne.surf.roleplay.api.mechanic.rentable.utils.door
 
 import it.unimi.dsi.fastutil.objects.ObjectSet
 
+/**
+ * Represents a container that holds a set of doors.
+ */
 interface DoorContainer {
     /**
      * A set of doors associated with the container.

--- a/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/RentableImpl.kt
+++ b/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/RentableImpl.kt
@@ -127,7 +127,7 @@ abstract class RentableImpl(
             return RentableMemberAddEvent.MemberAddResult.Failure(RentableMemberAddEvent.MemberAddFailureReason.AlreadyMember)
         }
 
-        val event = RentableMemberRemoveEvent(this, player)
+        val event = RentableMemberAddEvent(this, player)
 
         if (!event.callEvent()) {
             return RentableMemberAddEvent.MemberAddResult.Failure(RentableMemberAddEvent.MemberAddFailureReason.EventCancelled)

--- a/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/listeners/RentableOnlineListener.kt
+++ b/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/listeners/RentableOnlineListener.kt
@@ -19,7 +19,7 @@ object RentableOnlineListener : Listener {
 
         plugin.launch {
             ownedRentables.forEach { rentable ->
-                rentable.setOwner(null, RentableOwnerChangeEvent.OwnerChangeReason.PlayerQuit)
+                rentable.setOwner(null, RentableOwnerChangeEvent.OwnerChangeReason.OwnerQuit)
             }
         }
     }

--- a/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/utils/containers/VaultStorageContainer.kt
+++ b/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/utils/containers/VaultStorageContainer.kt
@@ -13,14 +13,14 @@ import kotlin.time.Duration
 class VaultStorageContainer(
     rentable: Rentable,
     location: Location,
-    size: StorageContainer.StorageContainerSize
+    size: StorageContainer.StorageContainerSize,
+    override val crackDuration: Duration = size.vaultCrackDuration
 ) : StorageContainerImpl(
     rentable = rentable,
     location = location,
     type = StorageContainer.StorageContainerType.VAULT,
     size = size,
 ), Crackable {
-    override val crackDuration: Duration = size.vaultCrackDuration
     override var cracked: Boolean = false
 
     override suspend fun crack(


### PR DESCRIPTION
This pull request introduces documentation improvements and minor code adjustments across the `surf-roleplay-api` and `surf-roleplay-mechanic` modules. The most significant changes include adding detailed Kotlin documentation comments to interfaces and classes related to rentable properties, refining event handling logic, and correcting inconsistencies in event naming and parameters.

### Documentation Improvements

* [`surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/Rentable.kt`](diffhunk://#diff-4d8dcbe2a5a6cbe78c165209a8a3163a17a9215fe34176811d73f3a9cd902257R17-R20): Added documentation describing the `Rentable` interface and its role in the game.
* [`surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableMemberAddEvent.kt`](diffhunk://#diff-2cc510ebdf133c752e72d1efad8cba81c8d49292234dee00cf9fd6379de1faedR7-R48): Added detailed comments for the member addition event, including descriptions of results and failure reasons.
* [`surf-roleplay-api/src/main/kotlin/dev/slne/surf/roleplay/api/mechanic/rentable/events/RentableOwnerChangeEvent.kt`](diffhunk://#diff-7e06ba552a619a2b7f817b5dddd4f6f1f34a6b3559db733e74a2df42086357f4R9-R87): Enhanced documentation for the owner change event, including reasons for failure and cancellation. [[1]](diffhunk://#diff-7e06ba552a619a2b7f817b5dddd4f6f1f34a6b3559db733e74a2df42086357f4R9-R87) [[2]](diffhunk://#diff-7e06ba552a619a2b7f817b5dddd4f6f1f34a6b3559db733e74a2df42086357f4R99-R104) [[3]](diffhunk://#diff-7e06ba552a619a2b7f817b5dddd4f6f1f34a6b3559db733e74a2df42086357f4R116-R132)

### Code Adjustments

* [`surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/RentableImpl.kt`](diffhunk://#diff-5fd4dd3db5041533f65c381d18709a722068126ff43f8d64f730ca6da8b5f07eL130-R130): Fixed an incorrect event instantiation by replacing `RentableMemberRemoveEvent` with `RentableMemberAddEvent`.
* [`surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/listeners/RentableOnlineListener.kt`](diffhunk://#diff-0f0018c5ba89bc8cb80efb385bfcf24056a410cfd9e320744f14ccf3bd7b0ae2L22-R22): Renamed `PlayerQuit` to `OwnerQuit` for clarity in owner change events.

### Additional Enhancements

* [`surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/rentable/utils/containers/VaultStorageContainer.kt`](diffhunk://#diff-e77f245acec2bc07f0d532cd33f69e033c5b76dca0381d7efd87f8809df42a36L16-L23): Adjusted the `crackDuration` property initialization to streamline its definition.