### PR TITLE
chore: update surf npc

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 surf-database = "2.2.1-SNAPSHOT"
-surf-npc-api = "1.21.7-1.1.0-SNAPSHOT"
+surf-npc-api = "1.21.7-1.4.1-SNAPSHOT"
 
 [libraries]
 surf-database = { module = "dev.slne.surf:surf-database", version.ref = "surf-database" }

--- a/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/idcard/IdCardNpc.kt
+++ b/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/idcard/IdCardNpc.kt
@@ -2,12 +2,13 @@ package dev.slne.surf.roleplay.mechanic.mechanics.idcard
 
 import dev.slne.surf.npc.api.dsl.npc
 import dev.slne.surf.npc.api.surfNpcApi
+import dev.slne.surf.roleplay.mechanic.mechanicRegistryImpl
 
 object IdCardNpc {
     suspend fun spawnNpc() {
         val npcSkin = surfNpcApi.getSkin("MikeyLLP")
 
-        npc {
+        npc(mechanicRegistryImpl.plugin) {
             uniqueName = IdCardMechanicImpl.NPC_NAME
             displayName = {
                 primary("Bürgeramt")

--- a/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/license/LicenseMechanicImpl.kt
+++ b/surf-roleplay-mechanic/src/main/kotlin/dev/slne/surf/roleplay/mechanic/mechanics/license/LicenseMechanicImpl.kt
@@ -15,6 +15,7 @@ import dev.slne.surf.roleplay.api.mechanic.license.LicenseMechanic
 import dev.slne.surf.roleplay.api.mechanic.license.player.LicensePlayer
 import dev.slne.surf.roleplay.api.player.RpPlayer
 import dev.slne.surf.roleplay.mechanic.MechanicImpl
+import dev.slne.surf.roleplay.mechanic.mechanicRegistryImpl
 import dev.slne.surf.roleplay.mechanic.mechanics.license.db.PlayerLicenseTable
 import dev.slne.surf.roleplay.mechanic.mechanics.license.licenses.FishingLicenseImpl
 import dev.slne.surf.roleplay.mechanic.mechanics.license.licenses.VehicleLicenseImpl
@@ -89,7 +90,7 @@ object LicenseMechanicImpl : MechanicImpl(
     private suspend fun spawnNpc() {
         val npcSkin = surfNpcApi.getSkin("CastCrafter")
 
-        npc {
+        npc(mechanicRegistryImpl.plugin) {
             uniqueName = NPC_NAME
             displayName = {
                 primary("Lizenzhändler")


### PR DESCRIPTION
This pull request updates dependencies and refactors the way NPCs are spawned in the ID card and license mechanics by ensuring the correct plugin instance is passed. The most notable changes are an upgrade to the `surf-npc-api` version and updates to the NPC spawning calls to use the plugin reference, which is important for proper NPC registration and lifecycle management.

**Dependency updates:**

* Upgraded the `surf-npc-api` dependency from version `1.21.7-1.1.0-SNAPSHOT` to `1.21.7-1.4.1-SNAPSHOT` in `gradle/libs.versions.toml` to ensure compatibility with new API features.

**NPC spawning improvements:**

* Updated the NPC spawning calls in both `IdCardNpc` and `LicenseMechanicImpl` to pass `mechanicRegistryImpl.plugin` to the `npc` builder, ensuring the correct plugin instance is used for NPC management. [[1]](diffhunk://#diff-15e610c7151dc0cd78c3efc3201212082e8fbd311ddd0a26f186bca158aa9f27R5-R11) [[2]](diffhunk://#diff-419b4ad879126a1e10da1ffa99fbc8d9d0ac7be53b17a7797c8e83bc6a1bef44L92-R93)
* Added necessary import for `mechanicRegistryImpl` in both `IdCardNpc.kt` and `LicenseMechanicImpl.kt` for access to the plugin instance. [[1]](diffhunk://#diff-15e610c7151dc0cd78c3efc3201212082e8fbd311ddd0a26f186bca158aa9f27R5-R11) [[2]](diffhunk://#diff-419b4ad879126a1e10da1ffa99fbc8d9d0ac7be53b17a7797c8e83bc6a1bef44R18)